### PR TITLE
fix(notebooks): comment out `Pkg.activate`

### DIFF
--- a/notebooks/Chapter_00.jl
+++ b/notebooks/Chapter_00.jl
@@ -18,7 +18,7 @@ end
 using Pkg
 
 # ╔═╡ f5359bf0-28ff-4ff5-8e70-a2bcc687dfc0
-Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
+#Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
 
 # ╔═╡ bd37f4aa-5e4e-4823-b758-16c7ee2b2fa0
 begin

--- a/notebooks/Chapter_02.jl
+++ b/notebooks/Chapter_02.jl
@@ -8,7 +8,7 @@ using InteractiveUtils
 using Pkg
 
 # ╔═╡ df0344f8-dcec-42fe-869d-2e89369d2201
-Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
+#Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
 
 # ╔═╡ 39bd8de1-6664-4ffe-abcc-10b9f4788f36
 begin

--- a/notebooks/Chapter_03.jl
+++ b/notebooks/Chapter_03.jl
@@ -8,7 +8,7 @@ using InteractiveUtils
 using Pkg
 
 # ╔═╡ e7f1559d-6b7c-408e-b03c-0386f7fc586b
-Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
+#Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
 
 # ╔═╡ b7c94aeb-b8ca-49bd-8ece-dbbf6611e086
 begin

--- a/notebooks/Chapter_04_part_1.jl
+++ b/notebooks/Chapter_04_part_1.jl
@@ -8,7 +8,7 @@ using InteractiveUtils
 using Pkg, DrWatson
 
 # ╔═╡ f09ccff8-4036-4322-90e6-cdceb35eadfe
-Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
+#Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
 
 # ╔═╡ 18b5c138-9324-4c5a-86ca-be1e825ed11e
 begin

--- a/notebooks/Chapter_04_part_2.jl
+++ b/notebooks/Chapter_04_part_2.jl
@@ -8,7 +8,7 @@ using InteractiveUtils
 using Pkg, DrWatson
 
 # ╔═╡ b5243551-16c7-49b6-8ba7-c9be3c4c1401
-Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
+#Pkg.activate(expanduser("~/.julia/dev/SR2TuringPluto"))
 
 # ╔═╡ ee02bdae-99a6-417b-8dad-e9647ce30ede
 begin


### PR DESCRIPTION
Just a quick fix this time!

It looks like that line is something that's been helpful for testing on your end (it seems to be in most of the notebooks, but with many of those instances commented out), but it also looks like it disables Pluto's built-in package manager which was a bit confusing and meant I the `chapter_02` notebook gave me some issues after a Julia upgrade (I think) that meant I needed to re-install `Distributions`:
![image](https://github.com/StatisticalRethinkingJulia/SR2TuringPluto.jl/assets/6251883/39751455-5a2c-4cad-8510-84629ed8dba8)

I've just commented out the `Pkg.activate` statements that weren't already commented about, and now Pluto is back to handling (and automatically installing / updating) my dependencies!